### PR TITLE
Add n8n workflow for OpenRouter

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -1,0 +1,16 @@
+# n8n Workflows
+
+This directory contains an example workflow for integrating with the [OpenRouter](https://openrouter.ai/) API using [n8n](https://n8n.io/).
+
+## Environment Variable
+
+The workflow expects an environment variable named `OPENROUTER_API_KEY` to be available in your n8n instance. Set this variable with your OpenRouter API key before executing the workflow.
+
+## Importing the Workflow
+
+1. Open your n8n editor UI.
+2. Click on **Workflow** > **Import from file**.
+3. Select `openrouter-workflow.json` from this directory.
+4. Save the workflow and execute it. The `Prompt` and `Model` nodes allow you to adjust the message and model name before sending the request.
+
+The HTTP Request node uses the expression `{{$env.OPENROUTER_API_KEY}}` so no key is stored in the workflow file.

--- a/n8n/openrouter-workflow.json
+++ b/n8n/openrouter-workflow.json
@@ -1,0 +1,98 @@
+{
+  "name": "OpenRouter Prompt",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": 1,
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            {
+              "name": "prompt",
+              "value": ""
+            }
+          ]
+        }
+      },
+      "id": 2,
+      "name": "Prompt",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [200, 0]
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            {
+              "name": "model",
+              "value": "openai/gpt-4o"
+            }
+          ]
+        }
+      },
+      "id": 3,
+      "name": "Model",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [400, 0]
+    },
+    {
+      "parameters": {
+        "url": "https://openrouter.ai/api/v1/chat/completions",
+        "method": "POST",
+        "jsonParameters": true,
+        "headerParametersJson": "{\n  \"Authorization\": \"Bearer {{$env.OPENROUTER_API_KEY}}\",\n  \"Content-Type\": \"application/json\"\n}",
+        "bodyParametersJson": "{\n  \"model\": \"={{$json.model}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"={{$json.prompt}}\"\n    }\n  ]\n}"
+      },
+      "id": 4,
+      "name": "Send to OpenRouter",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [600, 0]
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prompt": {
+      "main": [
+        [
+          {
+            "node": "Model",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Model": {
+      "main": [
+        [
+          {
+            "node": "Send to OpenRouter",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an example n8n workflow for OpenRouter
- document how to import it and configure OPENROUTER_API_KEY

## Testing
- `npm test` *(fails: react-scripts not found)*