### PR TITLE
Add services carousel

### DIFF
--- a/src/components/UI/ServicesCarousel.tsx
+++ b/src/components/UI/ServicesCarousel.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Box, IconButton } from '@mui/material';
+import { ArrowBackIos, ArrowForwardIos } from '@mui/icons-material';
+import ServiceCard from './ServiceCard';
+
+interface ServiceItem {
+  title: string;
+  description: string;
+  image: string;
+  link: string;
+}
+
+interface ServicesCarouselProps {
+  services: ServiceItem[];
+}
+
+const ServicesCarousel: React.FC<ServicesCarouselProps> = ({ services }) => {
+  const [index, setIndex] = React.useState(0);
+
+  const handlePrev = () => {
+    setIndex((prev) => (prev === 0 ? services.length - 1 : prev - 1));
+  };
+
+  const handleNext = () => {
+    setIndex((prev) => (prev === services.length - 1 ? 0 : prev + 1));
+  };
+
+  return (
+    <Box sx={{ position: 'relative', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          width: `${services.length * 100}%`,
+          transform: `translateX(-${index * (100 / services.length)}%)`,
+          transition: 'transform 0.5s ease',
+        }}
+      >
+        {services.map((service) => (
+          <Box key={service.title} sx={{ flex: '0 0 100%', p: 2 }}>
+            <ServiceCard {...service} />
+          </Box>
+        ))}
+      </Box>
+      <IconButton
+        onClick={handlePrev}
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: 8,
+          transform: 'translateY(-50%)',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <ArrowBackIos />
+      </IconButton>
+      <IconButton
+        onClick={handleNext}
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          right: 8,
+          transform: 'translateY(-50%)',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <ArrowForwardIos />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default ServicesCarousel;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/icons-material';
 import { motion } from 'framer-motion';
 import ServiceCard from '../components/UI/ServiceCard';
+import ServicesCarousel from '../components/UI/ServicesCarousel';
 import TestimonialCard from '../components/UI/TestimonialCard';
 import { Link as RouterLink } from 'react-router-dom';
 
@@ -242,13 +243,7 @@ const HomePage: React.FC = () => {
             </Typography>
           </Box>
 
-          <Grid container spacing={4}>
-            {services.map((service, index) => (
-              <Grid item xs={12} sm={6} md={3} key={index}>
-                <ServiceCard {...service} />
-              </Grid>
-            ))}
-          </Grid>
+          <ServicesCarousel services={services} />
 
           <Box sx={{ textAlign: 'center', mt: 6 }}>
             <Button 


### PR DESCRIPTION
## Summary
- implement `ServicesCarousel` component for a simple slider
- replace the crowded services grid on the HomePage with the new carousel

## Testing
- `npm test --silent` *(fails: react-scripts not found)*