### PR TITLE
Add CORS headers to Netlify functions

### DIFF
--- a/netlify/functions/ai-chat.js
+++ b/netlify/functions/ai-chat.js
@@ -4,10 +4,21 @@
 const fetch = require('node-fetch');
 
 exports.handler = async (event, context) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: corsHeaders, body: '' };
+  }
+
   // Only allow POST requests
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,
+      headers: corsHeaders,
       body: JSON.stringify({ success: false, error: 'Method Not Allowed' })
     };
   }
@@ -21,6 +32,7 @@ exports.handler = async (event, context) => {
     if (!messages || !Array.isArray(messages)) {
       return {
         statusCode: 400,
+        headers: corsHeaders,
         body: JSON.stringify({ success: false, error: 'Messages array is required' })
       };
     }
@@ -31,9 +43,10 @@ exports.handler = async (event, context) => {
       console.error('OpenRouter API key is missing');
       return {
         statusCode: 500,
-        body: JSON.stringify({ 
-          success: false, 
-          error: 'Server configuration error' 
+        headers: corsHeaders,
+        body: JSON.stringify({
+          success: false,
+          error: 'Server configuration error'
         })
       };
     }
@@ -61,8 +74,9 @@ exports.handler = async (event, context) => {
       console.error('OpenRouter API error:', errorText);
       return {
         statusCode: response.status,
-        body: JSON.stringify({ 
-          success: false, 
+        headers: corsHeaders,
+        body: JSON.stringify({
+          success: false,
           error: `API error: ${response.status}`
         })
       };
@@ -73,9 +87,7 @@ exports.handler = async (event, context) => {
     // Return the AI message
     return {
       statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       body: JSON.stringify({
         success: true,
         message: data.choices[0].message.content
@@ -86,8 +98,9 @@ exports.handler = async (event, context) => {
     console.error('Error handling request:', error);
     return {
       statusCode: 500,
-      body: JSON.stringify({ 
-        success: false, 
+      headers: corsHeaders,
+      body: JSON.stringify({
+        success: false,
         error: error.message || 'Internal Server Error'
       })
     };

--- a/netlify/functions/update-twilio-drgregpedro.js
+++ b/netlify/functions/update-twilio-drgregpedro.js
@@ -1,9 +1,20 @@
 const twilio = require('twilio');
 
 exports.handler = async (event, context) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: corsHeaders, body: '' };
+  }
+
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,
+      headers: corsHeaders,
       body: JSON.stringify({ success: false, error: 'Method Not Allowed' })
     };
   }
@@ -15,6 +26,7 @@ exports.handler = async (event, context) => {
     if (!phoneNumberSid || !drgregpedro) {
       return {
         statusCode: 400,
+        headers: corsHeaders,
         body: JSON.stringify({ success: false, error: 'phoneNumberSid and drgregpedro are required' })
       };
     }
@@ -26,6 +38,7 @@ exports.handler = async (event, context) => {
       console.error('Twilio credentials missing');
       return {
         statusCode: 500,
+        headers: corsHeaders,
         body: JSON.stringify({ success: false, error: 'Server configuration error' })
       };
     }
@@ -39,13 +52,14 @@ exports.handler = async (event, context) => {
 
     return {
       statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       body: JSON.stringify({ success: true, sid: phoneNumber.sid, drgregpedro: phoneNumber.friendlyName })
     };
   } catch (error) {
     console.error('Twilio update error:', error);
     return {
       statusCode: 500,
+      headers: corsHeaders,
       body: JSON.stringify({ success: false, error: error.message || 'Internal Server Error' })
     };
   }


### PR DESCRIPTION
## Summary
- allow OPTIONS requests for Netlify functions
- add `Access-Control-Allow-*` headers to ai-chat and update-twilio-drgregpedro functions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*