### PR TITLE
Use Netlify functions for API default

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -9,7 +9,8 @@ interface ApiResponse<T = any> {
 }
 
 // Base URL for backend API
-const API_BASE_URL = process.env.REACT_APP_BACKEND_URL || 'https://pedrobackend.onrender.com';
+// Default to Netlify functions for local development/deployments
+const API_BASE_URL = process.env.REACT_APP_BACKEND_URL || '/.netlify/functions';
 
 /**
  * Generic function to make API requests


### PR DESCRIPTION
## Summary
- use Netlify functions as the default API endpoint

## Testing
- `npm test --silent` *(fails: react-scripts not found)*